### PR TITLE
Fix search bar overlap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,40 @@
-# YanTechDictionary
-This is a simple dictionary built with html css and vanilla js and free dictionary api
+# Dictionary App
+
+A dictionary web application originally built in 2022, now being actively improved
+with modern frontend practices, better structure, and enhanced user experience.
+
+## Motivation
+This project is a revisit of an earlier work to:
+- Improve code quality and structure
+- Enhance performance and usability
+- Apply professional Git and collaboration workflows
+- Treat the project as a real, evolving product
+
+## Current Features
+- Word search with definitions
+- Clean and simple interface
+- speech to text reader
+
+## Planned Improvements
+- User Account
+- AI agent
+- local storage
+- Improved search performance
+- Better UI/UX
+- Mobile responsiveness
+- Offline support
+- Code refactoring and modularization
+
+## Tech Stack
+- HTML
+- CSS
+- JavaScript
+- React and React Native (in the future)
+
+## Development Workflow
+- Issues are used to plan work
+- Feature branches for changes
+- Pull Requests for review and documentation
+
+## Status
+🚧 Actively under development

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
   </head>
   <body>
     <header class="header">
+
       <div class="header-container">
         <div class="logo-box">YanTech Free Dictionary</div>
 
@@ -32,8 +33,10 @@
               <button type="submit" class="search-btn">Find Your word</button>
             </div>
           </form>
+          
         </div>
       </div>
+
     </header>
 
     <div class="audio-container">

--- a/style.css
+++ b/style.css
@@ -25,20 +25,19 @@ body {
 
 .header {
   background-color: rgb(20, 20, 137);
-  height: 10vh;
+  height: 15vh;
+  padding: 2rem 5rem;
 }
 
 .header-container {
   display: flex;
   justify-content: space-between;
-  align-items: center;
-  padding: 2rem 10rem;
   position: relative;
 }
 
 .logo-box {
   color: rgb(135, 132, 132);
-  font-size: 3rem;
+  font-size: 2rem;
   font-weight: 800;
 }
 
@@ -65,6 +64,7 @@ form input {
   width: 60rem;
   border-radius: 1rem;
   outline: none;
+  border: none;
   color: rgb(49, 48, 48);
 }
 


### PR DESCRIPTION
### What was fixed 

- The search bar was overlapping on the audio container
- With simple css twiks, I fixed the issue
- -  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
### How I fixed it

-  I made sure that the search bar container stop centering its children with flex. 
 
### Screenshot Before
<img width="883" height="68" alt="issue-1" src="https://github.com/user-attachments/assets/af976b6c-07ea-4f28-ba9f-337dbfe14333" />

### Screenshot After
<img width="945" height="96" alt="fix-issue-1" src="https://github.com/user-attachments/assets/0e48553d-4c52-4ec4-a7fe-e0afa4636df8" />

### **Therefore Issue #2 is closed

